### PR TITLE
Makefile: fix checksum generation for basic.bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ all:
 	ca65 -g kernal/kernal.s
 	ld65 -C rom.cfg -o rom.bin basic/basic.o kernal/kernal.o -Ln rom.txt
 	# if it's the unchanged 901226-01 image, use old checksum algorithm
-	if [[ $$(crc32 basic.bin) == cfdebff8 ]]; then \
+	$$SHELL -c "if [ $$(crc32 basic.bin) == cfdebff8 ]; then \
 		python checksum.py --old basic.bin 0xa0 0x1f52; \
 	else \
 		python checksum.py --new basic.bin 0xa0 0x1f52; \
-	fi
+	fi"
 	python checksum.py --new kernal.bin 0xe0 0x4ac
 
 clean:


### PR DESCRIPTION
The Makefile executes some shell commands to select the correct checksum
calculation, but the make process throws an error:

/bin/sh: 1: [[: not found

which leads to a missing checksum calculation for' basic.bin'.

Fix the in-Makefile shell script by passing the script to a separate shell
instance.

Signed-off-by: Oliver Hartkopp <socketcan@hartkopp.net>